### PR TITLE
Add timeout when connecting

### DIFF
--- a/drda/__init__.py
+++ b/drda/__init__.py
@@ -118,5 +118,5 @@ class NotSupportedError(DatabaseError):
         DatabaseError.__init__(self, 'NotSupportedError')
 
 
-def connect(host, database, port, user=None, password=None, use_ssl=False, db_type=None):
-    return Connection(host, database, port, user, password, use_ssl, db_type)
+def connect(host, database, port, user=None, password=None, use_ssl=False, db_type=None, timeout=None):
+    return Connection(host, database, port, user, password, use_ssl, db_type, timeout)

--- a/drda/connection.py
+++ b/drda/connection.py
@@ -119,7 +119,7 @@ class Connection:
                         sectkn = v
         return secmec, sectkn
 
-    def __init__(self, host, database, port, user, password, use_ssl, db_type):
+    def __init__(self, host, database, port, user, password, use_ssl, db_type, timeout):
         self.host = host
         self.database = (database + ' ' * 18)[:18]
         self.port = port
@@ -158,6 +158,8 @@ class Connection:
             raise ValueError('Unknown database type:{}'.format(self.db_type))
 
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        if timeout is not None:
+            self.sock.settimeout(timeout)
         if use_ssl:
             self.sock = ssl.wrap_socket(self.sock)
         self.sock.connect((self.host, self.port))


### PR DESCRIPTION
This PR adds an optional `timeout` args for connection.

This prevent the client from hanging indefinitely when the server is not responding.