### PR TITLE
docs: update README with Python 3.11+, SSL CA details, and modern usage patterns (fixes #24)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Currently, we support only DB2.
 Requirements
 =============
 
-- Python 3.8+
+- Python 3.11+
 
 
 Installation
@@ -35,6 +35,7 @@ Db2
 https://www.ibm.com/analytics/db2
 
 Example
+-------
 
 No SSL
 +++++++++++++++++++++++++++++++++++++++++
@@ -48,6 +49,7 @@ No SSL
    cur.execute('select * from foo where name=?', ['alice'])
    for r in cur.fetchall():
        print(r[0], r[1])
+   conn.close()
 
 With SSL connection
 +++++++++++++++++++++++++++++++++++++++++
@@ -61,15 +63,51 @@ With SSL connection
    cur.execute('select * from foo where name=?', ['alice'])
    for r in cur.fetchall():
        print(r[0], r[1])
+   conn.close()
 
-With SSL and client certificate
+With SSL and CA certificate
 +++++++++++++++++++++++++++++++++++++++++
+
+To connect to a server with a self-signed certificate or custom CA (such as IBM Db2 on Cloud), pass the server's CA certificate file path via ``ssl_client_cert_path``:
 
 ::
 
    import drda
 
-   conn = drda.connect(host='serverhost', database='dbname', use_ssl=True, ssl_client_cert_path='/some/what/path/cert.crt', user='user', password='password', port=xxxxx)
+   conn = drda.connect(host='serverhost', database='dbname', use_ssl=True, ssl_client_cert_path='/path/to/ca-cert.crt', user='user', password='password', port=xxxxx)
+   cur = conn.cursor()
+   cur.execute('select * from foo where name=?', ['alice'])
+   for r in cur.fetchall():
+       print(r[0], r[1])
+   conn.close()
+
+Context Manager and Cursor Iteration
++++++++++++++++++++++++++++++++++++++++++
+
+Connections and cursors support Python context managers (``with`` statement), and cursors can be iterated directly without calling ``fetchall()``:
+
+::
+
+   import drda
+
+   with drda.connect(host='serverhost', database='dbname', user='user', password='password', port=xxxxx) as conn:
+       with conn.cursor() as cur:
+           cur.execute('select * from foo where name=?', ['alice'])
+           for r in cur:
+               print(r[0], r[1])
+
+Transactions
++++++++++++++++++++++++++++++++++++++++++
+
+Transactions can be explicitly committed or rolled back:
+
+::
+
+   cur.execute("insert into foo values (?, ?)", [1, 'alice'])
+   conn.commit()
+
+   # Or rollback changes:
+   # conn.rollback()
 
 AsyncIO
 +++++++++++++++++++++++++++++++++++++++++
@@ -80,12 +118,11 @@ AsyncIO
    import drda.aio
 
    async def main():
-       conn = await drda.aio.connect(host='serverhost', database='dbname', user='user', password='password', port=xxxxx, timeout=30)
-       cur = conn.cursor()
-       await cur.execute('select * from foo where name=?', ['alice'])
-       for r in await cur.fetchall():
-           print(r[0], r[1])
-       await conn.close()
+       async with await drda.aio.connect(host='serverhost', database='dbname', user='user', password='password', port=xxxxx, timeout=30) as conn:
+           async with conn.cursor() as cur:
+               await cur.execute('select * from foo where name=?', ['alice'])
+               async for r in cur:
+                   print(r[0], r[1])
 
    asyncio.run(main())
 
@@ -107,3 +144,12 @@ Execute test
 
    $ python test_db2.py
    $ python test_async_db2.py
+
+Optional environment variables for tests:
+
+- ``DB2_HOST`` (default: ``localhost``)
+- ``DB2_PORT`` (default: ``50000``)
+- ``DB2_DATABASE`` (default: ``testdb``)
+- ``DB2_USER`` (default: ``db2inst1``)
+- ``DB2_PASSWORD`` (default: ``password``)
+- ``SSL_CLIENT_CERT_PATH`` (default: ``None``)


### PR DESCRIPTION
This PR addresses and closes #24 by updating `README.rst` with the following improvements:

- **Python Version**: Updated requirement to Python 3.11+ to align with `pyproject.toml` and CI test matrix.
- **SSL CA Certificate**: Clarified that `ssl_client_cert_path` is used for server CA verification (e.g. self-signed Db2 on Cloud certificates).
- **Connection Cleanup**: Added `conn.close()` calls to synchronous examples.
- **Context Managers & Direct Iteration**: Documented `with` statement usage and direct cursor iteration (`for row in cur:`).
- **Transactions**: Documented explicit `conn.commit()` and `conn.rollback()`.
- **AsyncIO**: Modernized AsyncIO example to show `async with` and `async for row in cur:`.
- **Test Environment**: Documented optional environment variables used by the test suite.

Fixes #24