### PR TITLE
Fix PEP 249 exception instantiation and add unit tests (fixes #26)

### DIFF
--- a/.github/workflows/test_db2.yml
+++ b/.github/workflows/test_db2.yml
@@ -52,3 +52,7 @@ jobs:
     - name: Test (asyncio)
       run: |
         python test_async_db2.py
+
+    - name: Test (exceptions)
+      run: |
+        python test_exceptions.py

--- a/drda/__init__.py
+++ b/drda/__init__.py
@@ -66,14 +66,35 @@ ROWID = DBAPITypeObject()
 
 
 class Error(Exception):
-    def __init__(self, sqlcode, sqlstate, message):
-        self.sqlcode = sqlcode
-        self.sqlstate = sqlstate
-        self.message = message
+    def __init__(self, *args, **kwargs):
+        if len(args) == 3:
+            self.sqlcode, self.sqlstate, self.message = args
+        elif len(args) == 2:
+            self.sqlcode, self.message = args
+            self.sqlstate = kwargs.get('sqlstate')
+        elif len(args) == 1:
+            self.sqlcode = kwargs.get('sqlcode')
+            self.sqlstate = kwargs.get('sqlstate')
+            self.message = args[0]
+        elif len(args) == 0:
+            self.sqlcode = kwargs.get('sqlcode')
+            self.sqlstate = kwargs.get('sqlstate')
+            self.message = kwargs.get('message', '')
+        else:
+            self.sqlcode = kwargs.get('sqlcode')
+            self.sqlstate = kwargs.get('sqlstate')
+            self.message = ' '.join(str(a) for a in args)
         super(Error, self).__init__(str(self))
 
     def __str__(self):
-        return "SQLCODE=%d SQLSTATE=%s %s" % (self.sqlcode, self.sqlstate, self.message)
+        parts = []
+        if self.sqlcode is not None:
+            parts.append("SQLCODE=%s" % self.sqlcode)
+        if self.sqlstate is not None:
+            parts.append("SQLSTATE=%s" % self.sqlstate)
+        if self.message:
+            parts.append(str(self.message))
+        return " ".join(parts) if parts else str(self.message or '')
 
 
 class Warning(Exception):
@@ -93,8 +114,10 @@ class DisconnectByPeer(Warning):
 
 
 class InternalError(DatabaseError):
-    def __init__(self):
-        DatabaseError.__init__(self, -1, 'InternalError')
+    def __init__(self, *args, **kwargs):
+        if not args and not kwargs:
+            args = (-1, 'InternalError')
+        super(InternalError, self).__init__(*args, **kwargs)
 
 
 class OperationalError(DatabaseError):
@@ -114,8 +137,10 @@ class DataError(DatabaseError):
 
 
 class NotSupportedError(DatabaseError):
-    def __init__(self):
-        DatabaseError.__init__(self, 'NotSupportedError')
+    def __init__(self, *args, **kwargs):
+        if not args and not kwargs:
+            args = ('NotSupportedError',)
+        super(NotSupportedError, self).__init__(*args, **kwargs)
 
 
 def connect(host, database, port=50000, user=None, password=None, use_ssl=False, ssl_client_cert_path=None, timeout=None):

--- a/test_exceptions.py
+++ b/test_exceptions.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+##############################################################################
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2026 Hajime Nakagami<nakagami@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+##############################################################################
+"""Tests for PEP 249 exceptions"""
+import asyncio
+import unittest
+import drda
+import drda.cursor
+import drda.aio.cursor
+
+
+class TestExceptions(unittest.TestCase):
+    """PEP 249 exception hierarchy and instantiation tests (offline, no server needed)."""
+
+    def test_pep249_inheritance(self):
+        self.assertTrue(issubclass(drda.Error, Exception))
+        self.assertTrue(issubclass(drda.Warning, Exception))
+        self.assertTrue(issubclass(drda.InterfaceError, drda.Error))
+        self.assertTrue(issubclass(drda.DatabaseError, drda.Error))
+        self.assertTrue(issubclass(drda.DataError, drda.DatabaseError))
+        self.assertTrue(issubclass(drda.OperationalError, drda.DatabaseError))
+        self.assertTrue(issubclass(drda.IntegrityError, drda.DatabaseError))
+        self.assertTrue(issubclass(drda.InternalError, drda.DatabaseError))
+        self.assertTrue(issubclass(drda.ProgrammingError, drda.DatabaseError))
+        self.assertTrue(issubclass(drda.NotSupportedError, drda.DatabaseError))
+
+    def test_instantiate_all_exceptions_no_args(self):
+        for exc_cls in (
+            drda.Error,
+            drda.Warning,
+            drda.InterfaceError,
+            drda.DatabaseError,
+            drda.DataError,
+            drda.OperationalError,
+            drda.IntegrityError,
+            drda.InternalError,
+            drda.ProgrammingError,
+            drda.NotSupportedError,
+        ):
+            e = exc_cls()
+            self.assertIsInstance(e, exc_cls)
+
+    def test_instantiate_all_exceptions_one_arg(self):
+        for exc_cls in (
+            drda.Error,
+            drda.InterfaceError,
+            drda.DatabaseError,
+            drda.DataError,
+            drda.OperationalError,
+            drda.IntegrityError,
+            drda.InternalError,
+            drda.ProgrammingError,
+            drda.NotSupportedError,
+        ):
+            msg = f"{exc_cls.__name__} occurred"
+            e = exc_cls(msg)
+            self.assertIsInstance(e, exc_cls)
+            self.assertEqual(e.message, msg)
+            self.assertIsNone(e.sqlcode)
+            self.assertIsNone(e.sqlstate)
+            self.assertEqual(str(e), msg)
+
+    def test_three_args_sqlcode_sqlstate_message(self):
+        e = drda.OperationalError(-30081, "08001", "connection refused")
+        self.assertEqual(e.sqlcode, -30081)
+        self.assertEqual(e.sqlstate, "08001")
+        self.assertEqual(e.message, "connection refused")
+        self.assertEqual(str(e), "SQLCODE=-30081 SQLSTATE=08001 connection refused")
+
+    def test_two_args_sqlcode_message(self):
+        e = drda.DatabaseError(-1, "something failed")
+        self.assertEqual(e.sqlcode, -1)
+        self.assertIsNone(e.sqlstate)
+        self.assertEqual(e.message, "something failed")
+        self.assertEqual(str(e), "SQLCODE=-1 something failed")
+
+    def test_keyword_args(self):
+        e = drda.Error(sqlcode=-204, sqlstate="42704", message="table not found")
+        self.assertEqual(e.sqlcode, -204)
+        self.assertEqual(e.sqlstate, "42704")
+        self.assertEqual(e.message, "table not found")
+        self.assertEqual(str(e), "SQLCODE=-204 SQLSTATE=42704 table not found")
+
+    def test_internal_error_defaults(self):
+        e = drda.InternalError()
+        self.assertEqual(e.sqlcode, -1)
+        self.assertIsNone(e.sqlstate)
+        self.assertEqual(e.message, "InternalError")
+        self.assertEqual(str(e), "SQLCODE=-1 InternalError")
+
+        e2 = drda.InternalError("custom internal error")
+        self.assertEqual(e2.message, "custom internal error")
+
+    def test_not_supported_error_defaults(self):
+        e = drda.NotSupportedError()
+        self.assertEqual(e.message, "NotSupportedError")
+        self.assertEqual(str(e), "NotSupportedError")
+
+        e2 = drda.NotSupportedError("feature X is not supported")
+        self.assertEqual(e2.message, "feature X is not supported")
+        self.assertEqual(str(e2), "feature X is not supported")
+
+    def test_cursor_not_supported_error(self):
+        cur = drda.cursor.Cursor(None)
+        with self.assertRaises(drda.NotSupportedError):
+            cur.callproc("test_proc")
+        with self.assertRaises(drda.NotSupportedError):
+            cur.nextset("test_proc")
+
+    def test_cursor_lost_connection_operational_error(self):
+        cur = drda.cursor.Cursor(None)
+        with self.assertRaises(drda.OperationalError) as ctx:
+            cur.fetchone()
+        self.assertIn("08003:Lost connection", str(ctx.exception))
+        self.assertIsNone(ctx.exception.sqlcode)
+        self.assertIsNone(ctx.exception.sqlstate)
+
+    def test_async_cursor_lost_connection_operational_error(self):
+        cur = drda.aio.cursor.Cursor(None)
+        with self.assertRaises(drda.OperationalError) as ctx:
+            asyncio.run(cur.fetchone())
+        self.assertIn("08003:Lost connection", str(ctx.exception))
+        self.assertIsNone(ctx.exception.sqlcode)
+        self.assertIsNone(ctx.exception.sqlstate)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR fixes `TypeError` issues when instantiating database exceptions across the codebase, bringing exception handling into full compliance with PEP 249 (fixes #26).

### Changes
- **Flexible `Error.__init__`**: Accepts 0, 1, 2, or 3 positional arguments and keyword arguments (`sqlcode`, `sqlstate`, `message`). Preserves existing 3-argument DRDA packet parsing (`parse_sqlcard`) while allowing 1-argument messages (e.g., `OperationalError("08003:Lost connection")`) and 0-argument default calls.
- **Dynamic `Error.__str__`**: Formats the error string cleanly depending on which attributes are set (`SQLCODE=%s SQLSTATE=%s %s`, `SQLCODE=%s %s`, or just `message`).
- **Fix `InternalError` & `NotSupportedError`**: Constructors now handle 0-argument instantiation cleanly with sensible defaults (`sqlcode=-1, message='InternalError'` and `message='NotSupportedError'`), as well as custom messages.
- **Unit Tests (`test_exceptions.py`)**: Added an offline test suite covering:
  - Complete PEP 249 exception inheritance hierarchy
  - Instantiation with 0, 1, 2, 3 arguments and keyword arguments
  - Cursor methods raising `NotSupportedError` (`callproc`, `nextset`) and `OperationalError` (`fetchone`) without `TypeError`
- **CI Workflow**: Added a `Test (exceptions)` step in `.github/workflows/test_db2.yml` to automatically run `test_exceptions.py`.
