### PR TITLE
feat(cursor): support cursor.arraysize in fetchmany() as per PEP 249

### DIFF
--- a/drda/aio/cursor.py
+++ b/drda/aio/cursor.py
@@ -50,7 +50,9 @@ class AsyncCursor(Cursor):
             return self._rows.popleft()
         return None
 
-    async def fetchmany(self, size=1):
+    async def fetchmany(self, size=None):
+        if size is None:
+            size = self.arraysize
         rs = []
         for i in range(size):
             r = await self.fetchone()

--- a/drda/cursor.py
+++ b/drda/cursor.py
@@ -95,7 +95,9 @@ class Cursor:
             return self._rows.popleft()
         return None
 
-    def fetchmany(self, size=1):
+    def fetchmany(self, size=None):
+        if size is None:
+            size = self.arraysize
         rs = []
         for i in range(size):
             r = self.fetchone()

--- a/test_exceptions.py
+++ b/test_exceptions.py
@@ -24,6 +24,7 @@
 ##############################################################################
 """Tests for PEP 249 exceptions"""
 import asyncio
+import collections
 import unittest
 import drda
 import drda.cursor
@@ -143,6 +144,53 @@ class TestExceptions(unittest.TestCase):
         self.assertIn("08003:Lost connection", str(ctx.exception))
         self.assertIsNone(ctx.exception.sqlcode)
         self.assertIsNone(ctx.exception.sqlstate)
+
+    def test_fetchmany_respects_arraysize(self):
+        class FakeConn:
+            def is_connect(self):
+                return True
+
+        cur = drda.cursor.Cursor(FakeConn())
+        cur._rows = collections.deque([(i,) for i in range(10)])
+        self.assertEqual(cur.arraysize, 1)
+
+        # Default size=None uses arraysize (1)
+        self.assertEqual(cur.fetchmany(), [(0,)])
+
+        # Setting arraysize changes default fetch quantity
+        cur.arraysize = 3
+        self.assertEqual(cur.fetchmany(), [(1,), (2,), (3,)])
+
+        # Explicit size overrides arraysize
+        self.assertEqual(cur.fetchmany(2), [(4,), (5,)])
+        self.assertEqual(cur.fetchmany(), [(6,), (7,), (8,)])
+        self.assertEqual(cur.fetchmany(), [(9,)])
+        self.assertEqual(cur.fetchmany(), [])
+
+    def test_async_fetchmany_respects_arraysize(self):
+        class FakeConn:
+            def is_connect(self):
+                return True
+
+        async def run():
+            cur = drda.aio.cursor.AsyncCursor(FakeConn())
+            cur._rows = collections.deque([(i,) for i in range(10)])
+            self.assertEqual(cur.arraysize, 1)
+
+            # Default size=None uses arraysize (1)
+            self.assertEqual(await cur.fetchmany(), [(0,)])
+
+            # Setting arraysize changes default fetch quantity
+            cur.arraysize = 3
+            self.assertEqual(await cur.fetchmany(), [(1,), (2,), (3,)])
+
+            # Explicit size overrides arraysize
+            self.assertEqual(await cur.fetchmany(2), [(4,), (5,)])
+            self.assertEqual(await cur.fetchmany(), [(6,), (7,), (8,)])
+            self.assertEqual(await cur.fetchmany(), [(9,)])
+            self.assertEqual(await cur.fetchmany(), [])
+
+        asyncio.run(run())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

According to [PEP 249 (Cursor Objects)](https://peps.python.org/pep-0249/#fetchmany):

> `cursor.fetchmany([size=cursor.arraysize])`
> Fetch the next set of rows of a query result, returning a sequence of sequences. [...] The number of rows to fetch per call is specified by the parameter. **If it is not given, the cursor's `arraysize` determines the number of rows to be fetched.**

Previously, `Cursor.fetchmany` and `AsyncCursor.fetchmany` had `size=1` hardcoded as the default argument. As a result, setting `cur.arraysize = N` had no effect when calling `cur.fetchmany()` without arguments, always returning only 1 row.

### Changes

- Updated `Cursor.fetchmany(self, size=None)` and `AsyncCursor.fetchmany(self, size=None)`.
- If `size is None`, it falls back to `self.arraysize` (which defaults to `1` as initialized in `Cursor.__init__`).
- Explicit `size` calls (e.g. `cur.fetchmany(5)`) continue to work as before.
- Added offline unit tests in `test_exceptions.py` verifying:
  - Default `cur.fetchmany()` returns 1 row with default `arraysize=1`.
  - Setting `cur.arraysize = 3` causes `cur.fetchmany()` to return 3 rows.
  - Passing an explicit `size` overrides `cur.arraysize`.
  - Same parity verified for `drda.aio.cursor.AsyncCursor`.
  