### PR TITLE
fix(types): modernize DBAPITypeObject for Python 3 as per PEP 249

### DIFF
--- a/drda/__init__.py
+++ b/drda/__init__.py
@@ -24,6 +24,7 @@
 
 import datetime
 import decimal
+from . import utils
 from .connection import Connection
 
 VERSION = (0, 6, 2)
@@ -47,22 +48,81 @@ class DBAPITypeObject:
     def __init__(self, *values):
         self.values = values
 
-    def __cmp__(self, other):
-        if other in self.values:
-            return 0
-        if other < self.values:
-            return 1
-        else:
-            return -1
+    def __eq__(self, other):
+        if isinstance(other, DBAPITypeObject):
+            return self.values == other.values
+        return other in self.values
+
+    def __ne__(self, other):
+        return not (self == other)
+
+    def __hash__(self):
+        return hash(self.values)
+
+    def __repr__(self):
+        return f"<DBAPITypeObject {self.values}>"
 
 
-STRING = DBAPITypeObject(str)
-BINARY = DBAPITypeObject(bytes)
-NUMBER = DBAPITypeObject(int, decimal.Decimal)
-DATETIME = DBAPITypeObject(datetime.datetime, datetime.date, datetime.time)
-DATE = DBAPITypeObject(datetime.date)
-TIME = DBAPITypeObject(datetime.time)
-ROWID = DBAPITypeObject()
+STRING = DBAPITypeObject(
+    str,
+    utils.DRDA_TYPE_CHAR, utils.DRDA_TYPE_NCHAR,
+    utils.DRDA_TYPE_VARCHAR, utils.DRDA_TYPE_NVARCHAR,
+    utils.DRDA_TYPE_LONG, utils.DRDA_TYPE_NLONG,
+    utils.DRDA_TYPE_CSTR, utils.DRDA_TYPE_NCSTR,
+    utils.DRDA_TYPE_CLOBLOC, utils.DRDA_TYPE_NCLOBLOC,
+    utils.DRDA_TYPE_DBCSCLOBLOC, utils.DRDA_TYPE_NDBCSCLOBLOC,
+    utils.DRDA_TYPE_GRAPHIC, utils.DRDA_TYPE_NGRAPHIC,
+    utils.DRDA_TYPE_VARGRAPH, utils.DRDA_TYPE_NVARGRAPH,
+    utils.DRDA_TYPE_LONGRAPH, utils.DRDA_TYPE_NLONGRAPH,
+    utils.DRDA_TYPE_MIX, utils.DRDA_TYPE_NMIX,
+    utils.DRDA_TYPE_VARMIX, utils.DRDA_TYPE_NVARMIX,
+    utils.DRDA_TYPE_LONGMIX, utils.DRDA_TYPE_NLONGMIX,
+    utils.DRDA_TYPE_CSTRMIX, utils.DRDA_TYPE_NCSTRMIX,
+    utils.DRDA_TYPE_LSTR, utils.DRDA_TYPE_NLSTR,
+    utils.DRDA_TYPE_LSTRMIX, utils.DRDA_TYPE_NLSTRMIX,
+    utils.DRDA_TYPE_LOBCSBCS, utils.DRDA_TYPE_NLOBCSBCS,
+)
+BINARY = DBAPITypeObject(
+    bytes, bytearray, memoryview,
+    utils.DRDA_TYPE_FIXBYTE, utils.DRDA_TYPE_NFIXBYTE,
+    utils.DRDA_TYPE_VARBYTE, utils.DRDA_TYPE_NVARBYTE,
+    utils.DRDA_TYPE_LONGVARBYTE, utils.DRDA_TYPE_NLONGVARBYTE,
+    utils.DRDA_TYPE_LOBLOC, utils.DRDA_TYPE_NLOBLOC,
+    utils.DRDA_TYPE_FIXBYTES, utils.DRDA_TYPE_NFIXBYTES,
+    utils.DRDA_TYPE_VARBINARY, utils.DRDA_TYPE_NVARBINARY,
+    utils.DRDA_TYPE_LOBBYTES, utils.DRDA_TYPE_NLOBBYTES,
+)
+NUMBER = DBAPITypeObject(
+    int, float, decimal.Decimal,
+    utils.DRDA_TYPE_INTEGER, utils.DRDA_TYPE_NINTEGER,
+    utils.DRDA_TYPE_SMALL, utils.DRDA_TYPE_NSMALL,
+    utils.DRDA_TYPE_1BYTE_INT, utils.DRDA_TYPE_N1BYTE_INT,
+    utils.DRDA_TYPE_INTEGER8, utils.DRDA_TYPE_NINTEGER8,
+    utils.DRDA_TYPE_FLOAT4, utils.DRDA_TYPE_NFLOAT4,
+    utils.DRDA_TYPE_FLOAT8, utils.DRDA_TYPE_NFLOAT8,
+    utils.DRDA_TYPE_FLOAT16, utils.DRDA_TYPE_NFLOAT16,
+    utils.DRDA_TYPE_DECIMAL, utils.DRDA_TYPE_NDECIMAL,
+    utils.DRDA_TYPE_ZDECIMAL, utils.DRDA_TYPE_NZDECIMAL,
+    utils.DRDA_TYPE_NUMERIC_CHAR, utils.DRDA_TYPE_NNUMERIC_CHAR,
+    utils.DRDA_TYPE_DECFLOAT, utils.DRDA_TYPE_NDECFLOAT,
+)
+DATETIME = DBAPITypeObject(
+    datetime.datetime, datetime.date, datetime.time,
+    utils.DRDA_TYPE_DATE, utils.DRDA_TYPE_NDATE,
+    utils.DRDA_TYPE_TIME, utils.DRDA_TYPE_NTIME,
+    utils.DRDA_TYPE_TIMESTAMP, utils.DRDA_TYPE_NTIMESTAMP,
+)
+DATE = DBAPITypeObject(
+    datetime.date,
+    utils.DRDA_TYPE_DATE, utils.DRDA_TYPE_NDATE,
+)
+TIME = DBAPITypeObject(
+    datetime.time,
+    utils.DRDA_TYPE_TIME, utils.DRDA_TYPE_NTIME,
+)
+ROWID = DBAPITypeObject(
+    utils.DRDA_TYPE_ROWID, utils.DRDA_TYPE_NROWID,
+)
 
 
 class Error(Exception):

--- a/test_exceptions.py
+++ b/test_exceptions.py
@@ -25,10 +25,13 @@
 """Tests for PEP 249 exceptions"""
 import asyncio
 import collections
+import datetime
+import decimal
 import unittest
 import drda
 import drda.cursor
 import drda.aio.cursor
+from drda import utils
 
 
 class TestExceptions(unittest.TestCase):
@@ -191,6 +194,95 @@ class TestExceptions(unittest.TestCase):
             self.assertEqual(await cur.fetchmany(), [])
 
         asyncio.run(run())
+
+    def test_dbapi_type_objects_python_types(self):
+        # Bidirectional equality for Python types
+        self.assertEqual(drda.STRING, str)
+        self.assertEqual(str, drda.STRING)
+        self.assertNotEqual(drda.STRING, int)
+        self.assertNotEqual(int, drda.STRING)
+
+        self.assertEqual(drda.NUMBER, int)
+        self.assertEqual(int, drda.NUMBER)
+        self.assertEqual(drda.NUMBER, float)
+        self.assertEqual(float, drda.NUMBER)
+        self.assertEqual(drda.NUMBER, decimal.Decimal)
+        self.assertEqual(decimal.Decimal, drda.NUMBER)
+        self.assertNotEqual(drda.NUMBER, str)
+
+        self.assertEqual(drda.DATETIME, datetime.datetime)
+        self.assertEqual(datetime.datetime, drda.DATETIME)
+        self.assertEqual(drda.DATETIME, datetime.date)
+        self.assertEqual(drda.DATETIME, datetime.time)
+
+        self.assertEqual(drda.DATE, datetime.date)
+        self.assertEqual(datetime.date, drda.DATE)
+
+        self.assertEqual(drda.TIME, datetime.time)
+        self.assertEqual(datetime.time, drda.TIME)
+
+        self.assertEqual(drda.BINARY, bytes)
+        self.assertEqual(bytes, drda.BINARY)
+        self.assertEqual(drda.BINARY, bytearray)
+        self.assertEqual(drda.BINARY, memoryview)
+
+    def test_dbapi_type_objects_drda_constants(self):
+        # Bidirectional equality for DRDA internal types
+        self.assertEqual(drda.STRING, utils.DRDA_TYPE_CHAR)
+        self.assertEqual(utils.DRDA_TYPE_VARCHAR, drda.STRING)
+        self.assertEqual(drda.STRING, utils.DRDA_TYPE_CLOBLOC)
+        self.assertEqual(drda.STRING, utils.DRDA_TYPE_LOBCSBCS)
+
+        self.assertEqual(drda.NUMBER, utils.DRDA_TYPE_INTEGER)
+        self.assertEqual(utils.DRDA_TYPE_SMALL, drda.NUMBER)
+        self.assertEqual(drda.NUMBER, utils.DRDA_TYPE_FLOAT8)
+        self.assertEqual(drda.NUMBER, utils.DRDA_TYPE_DECIMAL)
+        self.assertEqual(drda.NUMBER, utils.DRDA_TYPE_DECFLOAT)
+
+        self.assertEqual(drda.DATETIME, utils.DRDA_TYPE_DATE)
+        self.assertEqual(drda.DATETIME, utils.DRDA_TYPE_TIME)
+        self.assertEqual(drda.DATETIME, utils.DRDA_TYPE_TIMESTAMP)
+
+        self.assertEqual(drda.DATE, utils.DRDA_TYPE_DATE)
+        self.assertEqual(drda.TIME, utils.DRDA_TYPE_TIME)
+
+        self.assertEqual(drda.BINARY, utils.DRDA_TYPE_FIXBYTE)
+        self.assertEqual(drda.BINARY, utils.DRDA_TYPE_VARBYTE)
+        self.assertEqual(drda.BINARY, utils.DRDA_TYPE_LOBLOC)
+        self.assertEqual(drda.BINARY, utils.DRDA_TYPE_LOBBYTES)
+
+        self.assertEqual(drda.ROWID, utils.DRDA_TYPE_ROWID)
+        self.assertEqual(drda.ROWID, utils.DRDA_TYPE_NROWID)
+
+    def test_dbapi_type_objects_hashable(self):
+        # Type objects can be used as dict keys (common in ORMs)
+        type_mapping = {
+            drda.STRING: "string",
+            drda.NUMBER: "number",
+            drda.DATETIME: "datetime",
+            drda.BINARY: "binary",
+            drda.ROWID: "rowid",
+        }
+        self.assertEqual(type_mapping[drda.STRING], "string")
+        self.assertEqual(type_mapping[drda.NUMBER], "number")
+        self.assertEqual(type_mapping[drda.DATETIME], "datetime")
+        self.assertEqual(type_mapping[drda.BINARY], "binary")
+        self.assertEqual(type_mapping[drda.ROWID], "rowid")
+
+    def test_dbapi_type_objects_cursor_description(self):
+        # Simulates checking cursor.description[i][1] == TYPE_OBJECT
+        simulated_description = [
+            ("ID", utils.DRDA_TYPE_INTEGER, None, None, None, None, None),
+            ("NAME", utils.DRDA_TYPE_VARCHAR, None, None, None, None, None),
+            ("CREATED_AT", utils.DRDA_TYPE_TIMESTAMP, None, None, None, None, None),
+            ("DATA", utils.DRDA_TYPE_LOBBYTES, None, None, None, None, None),
+            ("ROW_ID", utils.DRDA_TYPE_ROWID, None, None, None, None, None),
+        ]
+        self.assertEqual(simulated_description[0][1], drda.NUMBER)
+        self.assertEqual(simulated_description[1][1], drda.STRING)
+        self.assertEqual(simulated_description[2][1], drda.DATETIME)
+        self.assertEqual(simulated_description[3][1], drda.BINARY)
+        self.assertEqual(simulated_description[4][1], drda.ROWID)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

According to [PEP 249 (Type Objects and Constructors)](https://peps.python.org/pep-0249/#type-objects-and-constructors):
> The module should export the following constructors and singletons: `STRING`, `BINARY`, `NUMBER`, `DATETIME`, `ROWID` (along with `DATE`, `TIME`).
> **The type object must compare equal to the type of column description:**
> `cursor.description[i][1] == STRING`
> `cursor.description[i][1] == NUMBER`

Previously in `pydrda`:
1. `DBAPITypeObject` implemented `__cmp__`, which was standard in Python 2 but was removed in Python 3.0. Consequently, all equality checks (`drda.STRING == str`, `drda.NUMBER == int`, etc.) evaluated to `False` in Python 3.
2. `NUMBER` lacked `float`.
3. `ROWID` was instantiated empty (`DBAPITypeObject()`).
4. DRDA internal type codes returned by `cursor.description[i][1]` (e.g. `utils.DRDA_TYPE_INTEGER`, `utils.DRDA_TYPE_VARCHAR`) were not mapped to the type singletons.

### Changes

- **Modernized `DBAPITypeObject`**:
  - Implemented `__eq__`, `__ne__`, `__hash__`, and `__repr__`.
  - Supports bidirectional equality comparison (e.g. `drda.STRING == str` and `str == drda.STRING`).
  - Hashable so type objects can be used as dictionary keys (standard in ORMs and schema inspectors).
- **Comprehensive Type Mappings**:
  - `STRING`: mapped to `str` and DRDA character/string type constants (`DRDA_TYPE_CHAR`, `DRDA_TYPE_VARCHAR`, `DRDA_TYPE_CLOBLOC`, etc.).
  - `BINARY`: mapped to `bytes`, `bytearray`, `memoryview`, and DRDA binary constants (`DRDA_TYPE_FIXBYTE`, `DRDA_TYPE_VARBYTE`, `DRDA_TYPE_LOBBYTES`, etc.).
  - `NUMBER`: mapped to `int`, `float`, `decimal.Decimal`, and DRDA numeric constants (`DRDA_TYPE_INTEGER`, `DRDA_TYPE_SMALL`, `DRDA_TYPE_FLOAT*`, `DRDA_TYPE_DECIMAL`, `DRDA_TYPE_DECFLOAT`, etc.).
  - `DATETIME`: mapped to `datetime.datetime`, `datetime.date`, `datetime.time`, and DRDA date/time constants.
  - `DATE`, `TIME`, and `ROWID`: mapped to their respective Python types and DRDA constants.
- **Unit Tests (`test_exceptions.py`)**:
  - Added test cases verifying bidirectional equality with Python types.
  - Added test cases verifying matching against DRDA internal type codes.
  - Added test cases for dictionary key hashability.
  - Added simulated `cursor.description` column type matching.
