### PR TITLE
fix(cursor): correct PEP 249 method signatures for setinputsizes, setoutputsize, and nextset

### DIFF
--- a/drda/cursor.py
+++ b/drda/cursor.py
@@ -63,14 +63,14 @@ class Cursor:
         from drda import NotSupportedError
         raise NotSupportedError()
 
-    def nextset(self, procname, args=()):
+    def nextset(self, *args, **kwargs):
         from drda import NotSupportedError
         raise NotSupportedError()
 
-    def setinputsizes(sizes):
+    def setinputsizes(self, sizes):
         pass
 
-    def setoutputsize(size, column=None):
+    def setoutputsize(self, size, column=None):
         pass
 
     def execute(self, query, args=[]):

--- a/test_exceptions.py
+++ b/test_exceptions.py
@@ -22,7 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 ##############################################################################
-"""Tests for PEP 249 exceptions"""
+"""Tests for PEP 249 compliance (offline, no database server required)"""
 import asyncio
 import collections
 import datetime
@@ -35,7 +35,7 @@ from drda import utils
 
 
 class TestExceptions(unittest.TestCase):
-    """PEP 249 exception hierarchy and instantiation tests (offline, no server needed)."""
+    """PEP 249 compliance tests (exceptions, types, cursor methods; offline)."""
 
     def test_pep249_inheritance(self):
         self.assertTrue(issubclass(drda.Error, Exception))
@@ -129,8 +129,28 @@ class TestExceptions(unittest.TestCase):
         cur = drda.cursor.Cursor(None)
         with self.assertRaises(drda.NotSupportedError):
             cur.callproc("test_proc")
+        # Standard PEP 249: nextset() without arguments
+        with self.assertRaises(drda.NotSupportedError):
+            cur.nextset()
+        # With optional arguments
         with self.assertRaises(drda.NotSupportedError):
             cur.nextset("test_proc")
+
+    def test_cursor_setinputsizes_and_setoutputsize(self):
+        cur = drda.cursor.Cursor(None)
+        cur.setinputsizes([10, 20])
+        cur.setoutputsize(100)
+        cur.setoutputsize(100, 1)
+
+    def test_async_cursor_methods(self):
+        cur = drda.aio.cursor.AsyncCursor(None)
+        with self.assertRaises(drda.NotSupportedError):
+            cur.callproc("test_proc")
+        with self.assertRaises(drda.NotSupportedError):
+            cur.nextset()
+        cur.setinputsizes([10, 20])
+        cur.setoutputsize(100)
+        cur.setoutputsize(100, 1)
 
     def test_cursor_lost_connection_operational_error(self):
         cur = drda.cursor.Cursor(None)


### PR DESCRIPTION
### Summary

According to [PEP 249 (Cursor Objects)](https://peps.python.org/pep-0249/#cursor-objects):
1. `.setinputsizes(sizes)`: specifies memory areas for operation parameters (can be a no-op).
2. `.setoutputsize(size[, column])`: specifies column buffer size for large column fetches (can be a no-op).
3. `.nextset()`: skips to the next available result set, taking no required parameters.

### Problems Fixed

1. `setinputsizes` and `setoutputsize` in `drda/cursor.py` were missing the `self` parameter. Calling `cur.setinputsizes(...)` raised:
   ```text
   TypeError: Cursor.setinputsizes() takes 1 positional argument but 2 were given
   ```
   *(Note: SQLAlchemy's default dialect explicitly invokes `cursor.setinputsizes()` on statement executions).*
2. `nextset` required `procname` and `args=()`. Calling standard `cur.nextset()` without parameters raised:
   ```text
   TypeError: Cursor.nextset() missing 1 required positional argument: 'procname'
   ```

### Changes

- Added `self` to `Cursor.setinputsizes(self, sizes)` and `Cursor.setoutputsize(self, size, column=None)`.
- Updated `Cursor.nextset(self, *args, **kwargs)` to allow standard 0-argument calls while preserving backward compatibility if arguments are passed.
- Added unit tests in `test_exceptions.py` verifying clean execution of `setinputsizes`, `setoutputsize`, and `nextset()` without `TypeError` on both `Cursor` and `AsyncCursor`.
