### PR TITLE
feat: add DictCursor and AsyncDictCursor support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,6 +126,37 @@ AsyncIO
 
    asyncio.run(main())
 
+Dictionary Cursor
++++++++++++++++++++++++++++++++++++++++++
+
+To fetch query results as Python dictionaries instead of tuples:
+
+::
+
+   import drda
+
+   with drda.connect(host='serverhost', database='dbname', user='user', password='password', port=xxxxx) as conn:
+       with conn.cursor(drda.DictCursor) as cur:
+           cur.execute('select * from foo where name=?', ['alice'])
+           for r in cur:
+               print(r['ID'], r['NAME'])
+
+For asyncio, use ``drda.aio.AsyncDictCursor``:
+
+::
+
+   import asyncio
+   import drda.aio
+
+   async def main():
+       async with await drda.aio.connect(host='serverhost', database='dbname', user='user', password='password', port=xxxxx) as conn:
+           async with conn.cursor(drda.aio.AsyncDictCursor) as cur:
+               await cur.execute('select * from foo where name=?', ['alice'])
+               async for r in cur:
+                   print(r['ID'], r['NAME'])
+
+   asyncio.run(main())
+
 Unit Tests
 ================
 

--- a/drda/__init__.py
+++ b/drda/__init__.py
@@ -26,6 +26,7 @@ import datetime
 import decimal
 from . import utils
 from .connection import Connection
+from .cursor import Cursor, DictCursor
 
 VERSION = (0, 6, 2)
 __version__ = '%s.%s.%s' % VERSION

--- a/drda/aio/__init__.py
+++ b/drda/aio/__init__.py
@@ -22,7 +22,7 @@
 # SOFTWARE.
 ##############################################################################
 from drda.aio.connection import AsyncConnection
-from drda.aio.cursor import AsyncCursor
+from drda.aio.cursor import AsyncCursor, AsyncDictCursor
 
 
 async def connect(host, database, port=50000, user=None, password=None, use_ssl=False, ssl_client_cert_path=None, timeout=None):

--- a/drda/aio/connection.py
+++ b/drda/aio/connection.py
@@ -512,8 +512,9 @@ class AsyncConnection(Connection):
     def is_connect(self):
         return bool(self.sock)
 
-    def cursor(self):
-        return AsyncCursor(self)
+    def cursor(self, factory=None, cursor_factory=None):
+        cur_factory = factory or cursor_factory or AsyncCursor
+        return cur_factory(self)
 
     async def begin(self):
         # DRDA starts a unit of work implicitly

--- a/drda/aio/cursor.py
+++ b/drda/aio/cursor.py
@@ -77,3 +77,18 @@ class AsyncCursor(Cursor):
         if not r:
             raise StopAsyncIteration()
         return r
+
+
+class AsyncDictCursor(AsyncCursor):
+    def _row_to_dict(self, row):
+        if row is None:
+            return None
+        return {d[0]: val for d, val in zip(self.description, row)}
+
+    async def fetchone(self):
+        row = await super().fetchone()
+        return self._row_to_dict(row)
+
+    async def fetchall(self):
+        rows = await super().fetchall()
+        return [self._row_to_dict(r) for r in rows]

--- a/drda/connection.py
+++ b/drda/connection.py
@@ -495,8 +495,9 @@ class Connection:
     def is_connect(self):
         return bool(self.sock)
 
-    def cursor(self):
-        return Cursor(self)
+    def cursor(self, factory=None, cursor_factory=None):
+        cur_factory = factory or cursor_factory or Cursor
+        return cur_factory(self)
 
     def begin(self):
         # DRDA starts a unit of work implicitly

--- a/drda/cursor.py
+++ b/drda/cursor.py
@@ -130,3 +130,18 @@ class Cursor:
         if not r:
             raise StopIteration()
         return r
+
+
+class DictCursor(Cursor):
+    def _row_to_dict(self, row):
+        if row is None:
+            return None
+        return {d[0]: val for d, val in zip(self.description, row)}
+
+    def fetchone(self):
+        row = super().fetchone()
+        return self._row_to_dict(row)
+
+    def fetchall(self):
+        rows = super().fetchall()
+        return [self._row_to_dict(r) for r in rows]

--- a/test_async_db2.py
+++ b/test_async_db2.py
@@ -310,6 +310,14 @@ class TestAsyncDataType(unittest.IsolatedAsyncioTestCase):
         await cur.execute("SELECT * FROM test_bool")
         self.assertEqual(await cur.fetchall(), [(True, False, None)])
 
+    async def test_dict_cursor(self):
+        cur = self.connection.cursor(drda.aio.AsyncDictCursor)
+        await cur.execute("SELECT * FROM test_bool")
+        rows = await cur.fetchall()
+        self.assertEqual(len(rows), 1)
+        self.assertIsInstance(rows[0], dict)
+        self.assertEqual(rows[0], {"B1": True, "B2": False, "B3": None})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test_async_db2.py
+++ b/test_async_db2.py
@@ -249,6 +249,15 @@ class TestAsyncBasic(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(await cur.fetchall(), [])
         self.assertTrue(cur.closed)
 
+    async def test_dict_cursor(self):
+        cur = self.connection.cursor(drda.aio.AsyncDictCursor)
+        await cur.execute("INSERT INTO test_basic (s, i) VALUES ('test', 42)")
+        await cur.execute("SELECT s, i FROM test_basic")
+        row = await cur.fetchone()
+        self.assertIsInstance(row, dict)
+        self.assertEqual(row['S'], 'test')
+        self.assertEqual(row['I'], 42)
+
 
 class TestAsyncDataType(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
@@ -309,14 +318,6 @@ class TestAsyncDataType(unittest.IsolatedAsyncioTestCase):
         """)
         await cur.execute("SELECT * FROM test_bool")
         self.assertEqual(await cur.fetchall(), [(True, False, None)])
-
-    async def test_dict_cursor(self):
-        cur = self.connection.cursor(drda.aio.AsyncDictCursor)
-        await cur.execute("SELECT * FROM test_bool")
-        rows = await cur.fetchall()
-        self.assertEqual(len(rows), 1)
-        self.assertIsInstance(rows[0], dict)
-        self.assertEqual(rows[0], {"B1": True, "B2": False, "B3": None})
 
 
 if __name__ == "__main__":

--- a/test_db2.py
+++ b/test_db2.py
@@ -608,6 +608,15 @@ class TestDb212(unittest.TestCase):
         row = cur.fetchone()
         self.assertIn('hello', row[0])
 
+    def test_dict_cursor(self):
+        cur = self.connection.cursor(drda.DictCursor)
+        cur.execute("INSERT INTO test_basic (s, i) VALUES ('test', 42)")
+        cur.execute("SELECT s, i FROM test_basic")
+        row = cur.fetchone()
+        self.assertIsInstance(row, dict)
+        self.assertEqual(row['S'], 'test')
+        self.assertEqual(row['I'], 42)
+
 
 if __name__ == "__main__":
     import unittest

--- a/test_db2.py
+++ b/test_db2.py
@@ -162,6 +162,15 @@ class TestBasic(unittest.TestCase):
             self.assertEqual(r, (s,))
         self.assertEqual(len(results), count)
 
+    def test_dict_cursor(self):
+        cur = self.connection.cursor(drda.DictCursor)
+        cur.execute("INSERT INTO test_basic (s, i) VALUES ('test', 42)")
+        cur.execute("SELECT s, i FROM test_basic")
+        row = cur.fetchone()
+        self.assertIsInstance(row, dict)
+        self.assertEqual(row['S'], 'test')
+        self.assertEqual(row['I'], 42)
+
 
 class TestDataType(unittest.TestCase):
     def setUp(self):
@@ -607,15 +616,6 @@ class TestDb212(unittest.TestCase):
         cur.execute("SELECT XMLSERIALIZE(x AS CLOB) FROM test_xml")
         row = cur.fetchone()
         self.assertIn('hello', row[0])
-
-    def test_dict_cursor(self):
-        cur = self.connection.cursor(drda.DictCursor)
-        cur.execute("INSERT INTO test_basic (s, i) VALUES ('test', 42)")
-        cur.execute("SELECT s, i FROM test_basic")
-        row = cur.fetchone()
-        self.assertIsInstance(row, dict)
-        self.assertEqual(row['S'], 'test')
-        self.assertEqual(row['I'], 42)
 
 
 if __name__ == "__main__":

--- a/test_exceptions.py
+++ b/test_exceptions.py
@@ -285,5 +285,165 @@ class TestExceptions(unittest.TestCase):
         self.assertEqual(simulated_description[4][1], drda.ROWID)
 
 
+class TestDictCursor(unittest.TestCase):
+    """Tests for DictCursor and AsyncDictCursor (offline, no server needed)."""
+
+    def test_exports(self):
+        self.assertTrue(hasattr(drda, "Cursor"))
+        self.assertTrue(hasattr(drda, "DictCursor"))
+        self.assertTrue(issubclass(drda.DictCursor, drda.Cursor))
+        self.assertTrue(hasattr(drda.aio, "AsyncCursor"))
+        self.assertTrue(hasattr(drda.aio, "AsyncDictCursor"))
+        self.assertTrue(issubclass(drda.aio.AsyncDictCursor, drda.aio.AsyncCursor))
+
+    def test_connection_cursor_factory(self):
+        class FakeConn(drda.Connection):
+            def __init__(self):
+                self.sock = None
+
+        conn = FakeConn()
+        # Default is Cursor
+        c1 = conn.cursor()
+        self.assertIsInstance(c1, drda.Cursor)
+        self.assertNotIsInstance(c1, drda.DictCursor)
+
+        # Positional factory
+        c2 = conn.cursor(drda.DictCursor)
+        self.assertIsInstance(c2, drda.DictCursor)
+
+        # Named cursor_factory
+        c3 = conn.cursor(cursor_factory=drda.DictCursor)
+        self.assertIsInstance(c3, drda.DictCursor)
+
+        # Named factory
+        c4 = conn.cursor(factory=drda.DictCursor)
+        self.assertIsInstance(c4, drda.DictCursor)
+
+    def test_async_connection_cursor_factory(self):
+        class FakeAsyncConn(drda.aio.AsyncConnection):
+            def __init__(self):
+                self.sock = None
+
+        conn = FakeAsyncConn()
+        c1 = conn.cursor()
+        self.assertIsInstance(c1, drda.aio.AsyncCursor)
+        self.assertNotIsInstance(c1, drda.aio.AsyncDictCursor)
+
+        c2 = conn.cursor(drda.aio.AsyncDictCursor)
+        self.assertIsInstance(c2, drda.aio.AsyncDictCursor)
+
+        c3 = conn.cursor(cursor_factory=drda.aio.AsyncDictCursor)
+        self.assertIsInstance(c3, drda.aio.AsyncDictCursor)
+
+        c4 = conn.cursor(factory=drda.aio.AsyncDictCursor)
+        self.assertIsInstance(c4, drda.aio.AsyncDictCursor)
+
+    def test_dict_cursor_fetch_methods(self):
+        class FakeConn:
+            def is_connect(self):
+                return True
+
+        cur = drda.DictCursor(FakeConn())
+        cur.description = [
+            ("ID", utils.DRDA_TYPE_INTEGER, None, None, None, None, None),
+            ("NAME", utils.DRDA_TYPE_VARCHAR, None, None, None, None, None),
+        ]
+        cur._rows = collections.deque([
+            (1, "Alice"),
+            (2, "Bob"),
+            (3, "Charlie"),
+            (4, "Dave"),
+            (5, "Eve"),
+        ])
+
+        # fetchone
+        r1 = cur.fetchone()
+        self.assertEqual(r1, {"ID": 1, "NAME": "Alice"})
+
+        # fetchmany with explicit size
+        r2 = cur.fetchmany(2)
+        self.assertEqual(r2, [
+            {"ID": 2, "NAME": "Bob"},
+            {"ID": 3, "NAME": "Charlie"},
+        ])
+
+        # fetchall
+        r3 = cur.fetchall()
+        self.assertEqual(r3, [
+            {"ID": 4, "NAME": "Dave"},
+            {"ID": 5, "NAME": "Eve"},
+        ])
+
+        # Empty fetches
+        self.assertIsNone(cur.fetchone())
+        self.assertEqual(cur.fetchmany(), [])
+        self.assertEqual(cur.fetchall(), [])
+
+    def test_dict_cursor_iteration(self):
+        class FakeConn:
+            def is_connect(self):
+                return True
+
+        cur = drda.DictCursor(FakeConn())
+        cur.description = [("VAL", utils.DRDA_TYPE_INTEGER, None, None, None, None, None)]
+        cur._rows = collections.deque([(10,), (20,)])
+
+        collected = list(cur)
+        self.assertEqual(collected, [{"VAL": 10}, {"VAL": 20}])
+
+    def test_async_dict_cursor_fetch_methods(self):
+        class FakeConn:
+            def is_connect(self):
+                return True
+
+        async def run():
+            cur = drda.aio.AsyncDictCursor(FakeConn())
+            cur.description = [
+                ("A", utils.DRDA_TYPE_INTEGER, None, None, None, None, None),
+                ("B", utils.DRDA_TYPE_VARCHAR, None, None, None, None, None),
+            ]
+            cur._rows = collections.deque([
+                (100, "X"),
+                (200, "Y"),
+                (300, "Z"),
+            ])
+
+            # fetchone
+            r1 = await cur.fetchone()
+            self.assertEqual(r1, {"A": 100, "B": "X"})
+
+            # fetchmany
+            r2 = await cur.fetchmany(1)
+            self.assertEqual(r2, [{"A": 200, "B": "Y"}])
+
+            # fetchall
+            r3 = await cur.fetchall()
+            self.assertEqual(r3, [{"A": 300, "B": "Z"}])
+
+            # Empty fetches
+            self.assertIsNone(await cur.fetchone())
+            self.assertEqual(await cur.fetchmany(), [])
+            self.assertEqual(await cur.fetchall(), [])
+
+        asyncio.run(run())
+
+    def test_async_dict_cursor_iteration(self):
+        class FakeConn:
+            def is_connect(self):
+                return True
+
+        async def run():
+            cur = drda.aio.AsyncDictCursor(FakeConn())
+            cur.description = [("V", utils.DRDA_TYPE_VARCHAR, None, None, None, None, None)]
+            cur._rows = collections.deque([("first",), ("second",)])
+
+            collected = []
+            async for row in cur:
+                collected.append(row)
+            self.assertEqual(collected, [{"V": "first"}, {"V": "second"}])
+
+        asyncio.run(run())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Summary

This PR adds dictionary-based cursor support for both synchronous and asynchronous modes:
- **`drda.DictCursor`**: Returns query results as dictionaries mapping column names to values (`dict[str, Any]`).
- **`drda.aio.AsyncDictCursor`**: Asyncio-compatible dictionary cursor supporting `async for` and `await fetchone()`.
- **Factory support in `Connection.cursor()`**: Allows passing cursor factories via `conn.cursor(drda.DictCursor)` or `conn.cursor(cursor_factory=drda.DictCursor)` / `conn.cursor(factory=...)`, following the DB-API conventions of `psycopg2` and `pymysql`.

### Features & Implementation

1. **`drda/cursor.py`**:
   - Added `DictCursor(Cursor)` which converts rows to dictionaries based on `self.description`.
   - Supports `fetchone()`, `fetchmany()`, `fetchall()`, and direct iteration (`for row in cur`).

2. **`drda/aio/cursor.py`**:
   - Added `AsyncDictCursor(AsyncCursor)`.
   - Supports `await fetchone()`, `await fetchmany()`, `await fetchall()`, and async iteration (`async for row in cur`).

3. **`drda/connection.py` & `drda/aio/connection.py`**:
   - Updated `cursor(self, factory=None, cursor_factory=None)` to instantiate custom cursors dynamically while defaulting to standard `Cursor` / `AsyncCursor` (100% backward compatible).

4. **Exports**:
   - Exported `Cursor` and `DictCursor` in `drda/__init__.py`.
   - Exported `AsyncCursor` and `AsyncDictCursor` in `drda/aio/__init__.py`.

5. **Tests**:
   - Added `TestDictCursor` offline test suite in `test_exceptions.py` covering exports, factory arguments, row conversion, and iteration.
   - Added integration tests in `test_db2.py` and `test_async_db2.py`.

6. **Documentation**:
   - Added "Dictionary Cursor" usage section to `README.rst`.
